### PR TITLE
override default config for redactor (allows unsafe html/script tags)

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/wysiwyg.js
+++ b/app/assets/javascripts/comfy/admin/cms/wysiwyg.js
@@ -39,7 +39,14 @@
       imageManagerJson,
       fileUpload,
       fileManagerJson,
-      definedLinks
+      definedLinks,
+      // allow unsafe tags and the like (prevent redactor stripping divs and other elements)
+      cleanOnEnter: false,
+      replaceTags: false,
+      removeComments: false,
+      removeNewLines: false,
+      deniedTags: [],
+      replaceDivs: false
     };
   };
 


### PR DESCRIPTION
### Summary

Since our usecase is for a multi tenant app, security is not a huge concern because unsafe tags will only affect the current tenant if they choose to misuse them. So I went ahead and allowed all HTML tags
