### PR TITLE
Fix for ruby 3.0

### DIFF
--- a/app/views/comfy/admin/cms/pages/_form.html.haml
+++ b/app/views/comfy/admin/cms/pages/_form.html.haml
@@ -26,6 +26,6 @@
 = comfy_admin_partial "comfy/admin/cms/partials/page_form_after", form: form
 
 = form.form_actions do
-  = submit_tag t(".preview"), name: "preview", formtarget: "comfy-cms-preview", id: nil, class: "btn btn-secondary", data: {disable_with: false}
-  = submit_tag t(@page.new_record?? ".create" : ".update"), class: "btn btn-primary ml-sm-1", data: {disable_with: false}
+  = submit_tag t(".preview"), name: "preview", formtarget: "comfy-cms-preview", id: nil, class: "btn btn-secondary"
+  = submit_tag t(@page.new_record?? ".create" : ".update"), class: "btn btn-primary ml-sm-1"
   = link_to t(".cancel"), comfy_admin_cms_site_pages_path, class: "btn btn-link"

--- a/lib/comfortable_mexican_sofa/routing.rb
+++ b/lib/comfortable_mexican_sofa/routing.rb
@@ -6,7 +6,7 @@ require_relative "routes/cms"
 class ActionDispatch::Routing::Mapper
 
   def comfy_route(identifier, options = {})
-    send("comfy_route_#{identifier}", options)
+    send("comfy_route_#{identifier}", **options)
   end
 
 end


### PR DESCRIPTION
### Summary

When trying to load up the application in Rails 6.1 and Ruby 3.0, you get an error (sorry missing the error message here, but trust me).  This fixes the error by adding the ** operator so that the passed in hash matches the named parameters.


